### PR TITLE
Fix webpack compilation on Mac

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = {
     rules: [
       {
         test: /\.js$/,
+	include: path.join(__dirname, '/src/client'),
         exclude: /node_modules/,
         use: {
           loader: 'babel-loader'


### PR DESCRIPTION
There is currently an error during compilation with webpack. There is a 'wdm: Failed to compile' error. This is solved by explicitly stating the path to the index.js file.