### PR TITLE
Windows platform compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "npm run build && node src/server/index.js",
     "client": "webpack-dev-server --mode development --devtool inline-source-map --hot",
     "server": "nodemon src/server/index.js",
-    "dev": "concurrently 'npm run server' 'npm run client'"
+    "dev": "concurrently \"npm run server\" \"npm run client\""
   },
   "author": "Sandeep Raveesh",
   "license": "ISC",


### PR DESCRIPTION
Switching to escaped doublequotes for concurrently makes it work on Windows platform.
See concurrently introduction https://github.com/kimmobrunfeldt/concurrently#readme