### PR TITLE
Update webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,6 +34,7 @@ module.exports = {
   devServer: {
     port: 3000,
     open: true,
+    historyApiFallback: true,
     proxy: {
       '/api': 'http://localhost:8080'
     }


### PR DESCRIPTION
Attempting to use the node module, [react-router-dom](https://github.com/ReactTraining/react-router), specifically Routing any more than the default root route, will fail without this configuration set. Took me way too long to debug this, and I think it's reasonable to expect novices branching off this template to run in to.

Really love this boilerplate, hope you think it's a reasonable change. Thanks!